### PR TITLE
Link to Documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ The Quality Assurance Archive & Communication (QuAAC) project is a standardizati
 storage and exchange of routine quality assurance data that spans vendors and
 inter-clinical sites.
 
+Documentation
+-------------
+Visit the `Full Documentation <https://quaac.readthedocs.io/>`_ on Read The Docs for a detailed description.
+
 Rationale
 ---------
 


### PR DESCRIPTION
I think Readme should have a link to ReadTheDocs. Otherwise, it could be difficult to find it. (I realized there was a ReadTheDocs documentation until I saw it on pylinac changelog 3.25).